### PR TITLE
make h5ppFormat use bundled/core.h for fmt bundle

### DIFF
--- a/include/h5pp/details/h5ppFormat.h
+++ b/include/h5pp/details/h5ppFormat.h
@@ -7,7 +7,7 @@
 #endif
 
 #if defined(H5PP_USE_FMT) || defined(H5PP_USE_SPDLOG)
-    #if __has_include(<spdlog/fmt/fmt.h>)
+    #if __has_include(<spdlog/fmt/bundled/core.h>)
         // Spdlog will include the bundled fmt unless SPDLOG_FMT_EXTERNAL is defined, in which case <fmt/core.h> gets included instead
         // If SPDLOG_HEADER_ONLY is defined this will cause FMT_HEADER_ONLY to also get defined
         #include <spdlog/fmt/fmt.h>


### PR DESCRIPTION
h5ppFormat currently uses the existence of <spdlog/fmt/fmt.h> to detect if spdlog is using a bundled fmt. However, this actually seems to be the
    file through which spdlog decides whether to use its bundled version
    or not - and therefore must be included in every spdlog install.
    Instead it's probably better to check if <spdlog/fmt/bundled/core.h>
    exists to see if the bundling exists.

This still introduces a potential discrepency with what <spdlog/fmt/fmt.h> does - which only depends on macro definitions. That is probably the more robust way to implement h5ppFormat in the future