### PR TITLE
Mtao/fix fmt namespaces

### DIFF
--- a/include/h5pp/details/h5ppFormat.h
+++ b/include/h5pp/details/h5ppFormat.h
@@ -49,10 +49,12 @@ namespace h5pp {
     #if defined(FMT_VERSION) && FMT_VERSION >= 81000
     using fmt::format;
     using fmt::print;
+    using fmt::ptr;
     using fmt::runtime;
     #else
     using fmt::format;
     using fmt::print;
+    using fmt::ptr;
     template<typename... Args>
     [[nodiscard]] std::string runtime(Args... args) {
         return fmt::format(std::forward<Args>(args)...);
@@ -161,6 +163,17 @@ namespace h5pp {
     template<typename... Args>
     void print(Args... args) {
         std::printf("%s", h5pp::format(std::forward<Args>(args)...).c_str());
+    }
+
+    template<typename T>
+    [[nodiscard]] auto ptr(T p) -> const void *;
+    template<typename T>
+    [[nodiscard]] auto ptr(const std::unique_ptr<T> &p) -> const void * {
+        return p.get();
+    }
+    template<typename T>
+    [[nodiscard]] auto ptr(const std::shared_ptr<T> &p) -> const void * {
+        return p.get();
     }
 }
 #endif

--- a/include/h5pp/details/h5ppFstr.h
+++ b/include/h5pp/details/h5ppFstr.h
@@ -91,21 +91,21 @@ namespace h5pp::type::flen {
         if(v.ptr == nullptr) return;
         strncpy(ptr, v.ptr, N);
         ptr[N - 1] = '\0';
-        if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t copied into {}: {}", fmt::ptr(ptr), ptr);
+        if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t copied into {}: {}", h5pp::ptr(ptr), ptr);
     }
     template<size_t N>
     inline fstr_t<N>::fstr_t(const char *v) {
         if(v == nullptr) return;
         strncpy(ptr, v, N);
         ptr[N - 1] = '\0';
-        if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t copied into {}: {}", fmt::ptr(ptr), ptr);
+        if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t copied into {}: {}", h5pp::ptr(ptr), ptr);
     }
     template<size_t N>
     inline fstr_t<N>::fstr_t(std::string_view v) {
         if(v.empty()) return;
         strncpy(ptr, v.data(), N);
         ptr[N - 1] = '\0';
-        if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t copied into {}: {}", fmt::ptr(ptr), ptr);
+        if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t copied into {}: {}", h5pp::ptr(ptr), ptr);
     }
 
     template<size_t N>
@@ -113,7 +113,7 @@ namespace h5pp::type::flen {
         if(v.ptr == nullptr) return;
         strncpy(ptr, v.ptr, N);
         ptr[N - 1] = '\0';
-        if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t copied into {}: {}", fmt::ptr(ptr), ptr);
+        if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t copied into {}: {}", h5pp::ptr(ptr), ptr);
     }
     template<size_t N>
     template<typename T, typename>
@@ -147,7 +147,7 @@ namespace h5pp::type::flen {
             clear();
             strncpy(ptr, v.ptr, N);
             ptr[N - 1] = '\0';
-            if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t assigned into {}: {}", fmt::ptr(ptr), ptr);
+            if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t assigned into {}: {}", h5pp::ptr(ptr), ptr);
         }
         return *this;
     }
@@ -156,7 +156,7 @@ namespace h5pp::type::flen {
         clear();
         strncpy(ptr, v.data(), N);
         ptr[N - 1] = '\0';
-        if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t assigned into {}: {}", fmt::ptr(ptr), ptr);
+        if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t assigned into {}: {}", h5pp::ptr(ptr), ptr);
         return *this;
     }
     template<size_t N>
@@ -271,7 +271,7 @@ namespace h5pp::type::flen {
         size_t oldlen = size();
         strncpy(ptr + oldlen, v, N - oldlen);
         ptr[N - 1] = '\0';
-        if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t appended to {} | {} -> {}", fmt::ptr(ptr), v, ptr);
+        if constexpr(internal::debug_fstr_t) h5pp::logger::log->info("fstr_t appended to {} | {} -> {}", h5pp::ptr(ptr), v, ptr);
     }
 
     template<size_t N>

--- a/include/h5pp/details/h5ppInfo.h
+++ b/include/h5pp/details/h5ppInfo.h
@@ -660,9 +660,9 @@ namespace h5pp {
             size_t nwidth = 4;
             for(const auto &name : fieldNames.value()) nwidth = std::max(nwidth, 1ul + name.size());
             /* clang-format off */
-            std::string msg = fmt::format("{1:4}: {2:{0}} | {3:6} | {4:6} | {5:16} | {6:24}\n", nwidth, "idx", "name", "size", "offset", "class", "type");
+            std::string msg = h5pp::format("{1:4}: {2:{0}} | {3:6} | {4:6} | {5:16} | {6:24}\n", nwidth, "idx", "name", "size", "offset", "class", "type");
             for(size_t m = 0; m < type::safe_cast<size_t>(numFields.value()); ++m) {
-                msg += fmt::format("{1:4}: {2:{0}} | {3:6} | {4:6} | {5:16} | {6:24}\n", nwidth,
+                msg += h5pp::format("{1:4}: {2:{0}} | {3:6} | {4:6} | {5:16} | {6:24}\n", nwidth,
                                          m,
                                          fieldNames and fieldNames->size() > m ? fieldNames->at(m) : "",
                                          fieldSizes and fieldSizes->size() > m ? fieldSizes->at(m) : -1ul,
@@ -876,9 +876,9 @@ namespace h5pp {
             size_t nwidth = 4;
             for(const auto &name : memberNames.value()) nwidth = std::max(nwidth, 1ul + name.size());
             /* clang-format off */
-            std::string msg = fmt::format("{1:4}: {2:{0}} | {3:6} | {4:6} | {5:16} | {6:24}\n", nwidth, "idx", "name", "size", "offset", "class", "type");
+            std::string msg = h5pp::format("{1:4}: {2:{0}} | {3:6} | {4:6} | {5:16} | {6:24}\n", nwidth, "idx", "name", "size", "offset", "class", "type");
             for(size_t m = 0; m < type::safe_cast<size_t>(numMembers.value()); ++m) {
-                msg += fmt::format("{1:4}: {2:{0}} | {3:6} | {4:6} | {5:16} | {6:24}\n", nwidth,
+                msg += h5pp::format("{1:4}: {2:{0}} | {3:6} | {4:6} | {5:16} | {6:24}\n", nwidth,
                                          m,
                                          memberNames and memberNames->size() > m ? memberNames->at(m) : "",
                                          memberSizes and memberSizes->size() > m ? memberSizes->at(m) : -1ul,

--- a/include/h5pp/details/h5ppType.h
+++ b/include/h5pp/details/h5ppType.h
@@ -62,12 +62,12 @@ namespace h5pp::type {
         if(type::custom::H5T_FLOAT<__float128>::equal(h5type)) return type::custom::H5T_FLOAT<__float128>::h5name();
 #endif
         if(H5Tget_class(h5type) == H5T_class_t::H5T_ENUM)      return h5pp::format("H5T_ENUM{}",H5Tget_size(h5type));
-        if(H5Tget_class(h5type) == H5T_class_t::H5T_ARRAY)     return fmt::format("H5T_ARRAY<{}>", getH5TypeName(H5Tget_super(h5type)));
+        if(H5Tget_class(h5type) == H5T_class_t::H5T_ARRAY)     return h5pp::format("H5T_ARRAY<{}>", getH5TypeName(H5Tget_super(h5type)));
         if(H5Tis_variable_str(h5type))                         return "H5T_VARIABLE";
         if(H5Tcommitted(h5type) == 0){
             hid::h5t h5native = H5Tget_native_type(h5type, H5T_direction_t::H5T_DIR_DEFAULT);
             if(H5Tequal(h5native, h5type) == 0)
-                return fmt::format("{}<{}>",getH5ClassName(h5type), getH5TypeName(h5native));
+                return h5pp::format("{}<{}>",getH5ClassName(h5type), getH5TypeName(h5native));
             // Just get the class and size...
             return h5pp::format("{}:{}",getH5ClassName(h5type), H5Tget_size(h5type));
         }

--- a/include/h5pp/details/h5ppVstr.h
+++ b/include/h5pp/details/h5ppVstr.h
@@ -86,7 +86,7 @@ namespace h5pp::type::vlen {
         ptr = static_cast<char *>(malloc(v.size() + 1 * sizeof(char)));
         strcpy(ptr, v.ptr);
         ptr[v.size()] = '\0';
-        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t allocated {}: {}", fmt::ptr(ptr), ptr);
+        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t allocated {}: {}", h5pp::ptr(ptr), ptr);
     }
     inline vstr_t::vstr_t(const char *v) {
         if(v == nullptr) return;
@@ -94,14 +94,14 @@ namespace h5pp::type::vlen {
         ptr        = static_cast<char *>(malloc(len + 1 * sizeof(char)));
         strcpy(ptr, v);
         ptr[len] = '\0';
-        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t allocated {}: {}", fmt::ptr(ptr), ptr);
+        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t allocated {}: {}", h5pp::ptr(ptr), ptr);
     }
     inline vstr_t::vstr_t(std::string_view v) {
         if(v.empty()) return;
         ptr = static_cast<char *>(malloc(v.size() + 1 * sizeof(char)));
         strcpy(ptr, v.data());
         ptr[v.size()] = '\0';
-        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t allocated {}: {}", fmt::ptr(ptr), ptr);
+        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t allocated {}: {}", h5pp::ptr(ptr), ptr);
     }
 
     inline vstr_t::vstr_t(vstr_t &&v) noexcept {
@@ -109,7 +109,7 @@ namespace h5pp::type::vlen {
         ptr = static_cast<char *>(malloc(v.size() + 1 * sizeof(char)));
         strcpy(ptr, v.ptr);
         ptr[v.size()] = '\0';
-        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t allocated {}: {}", fmt::ptr(ptr), ptr);
+        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t allocated {}: {}", h5pp::ptr(ptr), ptr);
     }
     template<typename T, typename>
     vstr_t::vstr_t(const T &v) {
@@ -143,7 +143,7 @@ namespace h5pp::type::vlen {
             ptr = static_cast<char *>(malloc(v.size() + 1 * sizeof(char)));
             strcpy(ptr, v.ptr);
             ptr[v.size()] = '\0';
-            if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t allocated {}: {}", fmt::ptr(ptr), ptr);
+            if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t allocated {}: {}", h5pp::ptr(ptr), ptr);
         }
         return *this;
     }
@@ -153,7 +153,7 @@ namespace h5pp::type::vlen {
         ptr = static_cast<char *>(malloc(v.size() + 1 * sizeof(char)));
         strcpy(ptr, v.data());
         ptr[v.size()] = '\0';
-        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t allocated {}: {}", fmt::ptr(ptr), ptr);
+        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t allocated {}: {}", h5pp::ptr(ptr), ptr);
         return *this;
     }
     template<typename T, typename>
@@ -217,7 +217,7 @@ namespace h5pp::type::vlen {
 
     inline void vstr_t::clear() noexcept {
         if constexpr(internal::debug_vstr_t) {
-            if(ptr != nullptr) h5pp::logger::log->info("vstr_t clearing {} | {}", fmt::ptr(ptr), ptr);
+            if(ptr != nullptr) h5pp::logger::log->info("vstr_t clearing {} | {}", h5pp::ptr(ptr), ptr);
         }
         free(ptr);
         ptr = nullptr;
@@ -229,7 +229,7 @@ namespace h5pp::type::vlen {
             throw;
         }
         ptr = newptr;
-        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t realloc {} | {}", fmt::ptr(ptr), ptr);
+        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t realloc {} | {}", h5pp::ptr(ptr), ptr);
     }
     inline void vstr_t::erase(std::string::size_type pos, std::string::size_type n) { *this = std::string(*this).erase(pos, n); }
     inline void vstr_t::erase(const char *b, const char *e) {
@@ -243,7 +243,7 @@ namespace h5pp::type::vlen {
         resize(oldlen + strlen(v));
         strcpy(ptr + oldlen, v);
         ptr[size()] = '\0';
-        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t appended to {} | {} -> {}", fmt::ptr(ptr), v, ptr);
+        if constexpr(internal::debug_vstr_t) h5pp::logger::log->info("vstr_t appended to {} | {} -> {}", h5pp::ptr(ptr), v, ptr);
     }
     inline void vstr_t::append(const std::string &v) { append(v.c_str()); }
     inline void vstr_t::append(std::string_view v) { append(v.data()); }


### PR DESCRIPTION
Disabling fmt was broken because some code used fmt::format and fmt::ptr. This PR borrows fmt::ptr just enough to get this library to work and switches uses of fmt::format to h5pp::format.